### PR TITLE
chore: bump MSRV to Rust 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 authors = ["Abdelkader Boudih <oss@seuros.com>"]
 license = "MIT"
 repository = "https://github.com/seuros/dictator"


### PR DESCRIPTION
The 1.95 release is all additive stabilisations