### PR TITLE
Profile inheritance fix, decree enabled gate, rubyfmt as first citizen

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -128,12 +128,13 @@ The `enforced` field in diagnostics indicates whether Dictator auto-fixed the vi
 | `true` | Dictator fixed it | 🔧 |
 | `false` | User must comply | ❌ |
 
-For external linters (RuboCop, ESLint, Biome, Clippy, Ruff), `enforced` is determined by whether the linter can auto-fix:
-- RuboCop: `correctable` field
-- ESLint: `fix` object presence
+For external linters (rubyfmt, Biome, Ruff, Clippy, plus legacy RuboCop/ESLint), `enforced` is determined by whether the linter can auto-fix:
+- rubyfmt: always rewrites in place (always enforced)
 - Biome: `tags` array contains `"fixable"`
-- Clippy: `MachineApplicable` suggestion
 - Ruff: `fix.applicability == "safe"`
+- Clippy: `MachineApplicable` suggestion
+- RuboCop (legacy): `correctable` field
+- ESLint (legacy): `fix` object presence
 
 ## MCP / AI Integration
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ AI coding assistants like Claude Code and OpenAI Codex can use Dictator not to �
 - **`stalint`** (Static Lint). Despite the name, it doesn’t “lint” in the classic sense — it just **reports** structural violations: trailing whitespace, line endings, file size, etc. Read-only. No surprises.
 - **`dictator`**. This one actually does things:
   - In **`kimjongrails`** mode, it fixes native structural errors (LF/CRLF, trailing spaces, missing final newlines, etc.).
-  - In **`supremecourt`** mode, it escalates to whatever primitive linters you already trust (RuboCop, ESLint, Prettier, Ruff, …) as defined in `.dictate.toml`.
+  - In **`supremecourt`** mode, it escalates to whatever linters you have configured — rubyfmt, Biome, Ruff, Clippy, Prettier, gofmt (or legacy RuboCop/ESLint if you must) — as defined in `.dictate.toml`.
 
 From the AI’s point of view, Dictator is the one calling the shots: external linters do the heavy lifting, Dictator orchestrates them, and then takes the credit.
 
@@ -446,7 +446,7 @@ MCP mode is auto-detected when stdin is a pipe and no CLI arguments are provided
 
 **Tool modes are dynamic:**
 - `kimjongrails`: Always available (basic structural fixes)
-- `supremecourt`: Only available if decrees have configured linters (e.g., `decree.ruby.linter.command = "rubocop"`)
+- `supremecourt`: Only available if decrees have configured linters (e.g., `decree.ruby.linter.command = "rubyfmt"`)
 
 ### Example Usage
 
@@ -488,7 +488,7 @@ The MCP server will:
 **Examples:**
 - Run from `/tmp` (no git) → LLM only sees `stalint` (read-only)
 - Run from project (has git) → LLM sees `dictator` but it rejects `/home` or `/etc`
-- No rubocop/eslint → `supremecourt` mode hidden from LLM
+- No rubyfmt/biome → `supremecourt` mode hidden from LLM
 
 **Note:** As of 2025, some MCP clients don't send sandbox notifications. See Claude Code issues [#3315](https://github.com/anthropics/claude-code/issues/3315), [#3174](https://github.com/anthropics/claude-code/issues/3174), [#3141](https://github.com/anthropics/claude-code/issues/3141) for related discussion.
 
@@ -498,7 +498,7 @@ The MCP server reads linter configurations from `.dictate.toml`:
 
 ```toml
 [decree.ruby.linter]
-command = "rubocop"
+command = "rubyfmt"  # or "rubocop" for existing .rubocop.yml configs
 
 [decree.typescript.linter]
 command = "biome"  # or "eslint" for existing ESLint configs
@@ -511,6 +511,7 @@ command = "gofmt"
 ```
 
 **Dictator controls the args.** You only specify the command. Dictator adds the appropriate flags for auto-fix and JSON output parsing:
+- `rubyfmt` → `-i` (write-in-place formatter)
 - `rubocop` → `-A --format json`
 - `biome` → `lint --write --reporter json`
 - `eslint` → `--fix --format json`
@@ -533,8 +534,8 @@ command = "gofmt"
 ```yaml
 - name: Structural checks (fast)
   run: dictator lint .  # Fails fast if structure is wrong
-- name: Quality checks (slow)
-  run: bundle exec rubocop
+- name: Formatting check (fast)
+  run: rubyfmt --check .   # legacy projects may swap in: bundle exec rubocop
 ```
 
 **Pre-commit workflow:**

--- a/crates/dictator-core/src/config.rs
+++ b/crates/dictator-core/src/config.rs
@@ -362,12 +362,7 @@ impl DictateConfig {
             )
             .map_err(|e| ConfigError::Parse(e.to_string()))?;
 
-        // Validate all decree settings
-        for (name, settings) in &config.decree {
-            settings
-                .validate()
-                .map_err(|e| ConfigError::Validation(format!("decree.{name}: {e}")))?;
-        }
+        config.validate_all_settings()?;
 
         Ok(config)
     }
@@ -408,11 +403,11 @@ impl DictateConfig {
     pub fn get_profile_config(&self, profile_name: &str) -> Result<Self, String> {
         let mut result = self.clone();
 
-        // Start with the requested profile
+        // Resolve parent profiles first so the requested profile remains most specific.
         let mut current_profile = profile_name;
         let mut visited_profiles = std::collections::HashSet::new();
+        let mut inheritance_chain = Vec::new();
 
-        // Resolve profile inheritance chain
         loop {
             if !visited_profiles.insert(current_profile.to_string()) {
                 return Err(format!(
@@ -420,28 +415,30 @@ impl DictateConfig {
                 ));
             }
 
-            if let Some(profile) = self.profile.get(current_profile) {
-                // Merge profile decree settings
-                for (decree_name, profile_settings) in &profile.decree {
-                    if let Some(base_settings) = result.decree.get_mut(decree_name) {
-                        // Merge settings (profile overrides base)
-                        merge_decree_settings(base_settings, profile_settings);
-                    } else {
-                        // Add new decree settings from profile
-                        result
-                            .decree
-                            .insert(decree_name.clone(), profile_settings.clone());
-                    }
-                }
+            let Some(profile) = self.profile.get(current_profile) else {
+                return Err(format!("Profile '{current_profile}' not found"));
+            };
+            inheritance_chain.push(profile);
 
-                // Check if this profile inherits from another
-                if let Some(parent) = &profile.inherits {
-                    current_profile = parent;
-                } else {
-                    break;
-                }
+            if let Some(parent) = &profile.inherits {
+                current_profile = parent;
             } else {
                 break;
+            }
+        }
+
+        for profile in inheritance_chain.iter().rev() {
+            // Merge profile decree settings
+            for (decree_name, profile_settings) in &profile.decree {
+                if let Some(base_settings) = result.decree.get_mut(decree_name) {
+                    // Merge settings (profile overrides base)
+                    merge_decree_settings(base_settings, profile_settings);
+                } else {
+                    // Add new decree settings from profile
+                    result
+                        .decree
+                        .insert(decree_name.clone(), profile_settings.clone());
+                }
             }
         }
 
@@ -465,6 +462,24 @@ impl DictateConfig {
             // No active profile or profile doesn't exist, use base config
             self.clone()
         }
+    }
+
+    fn validate_all_settings(&self) -> Result<(), ConfigError> {
+        for (name, settings) in &self.decree {
+            settings
+                .validate()
+                .map_err(|e| ConfigError::Validation(format!("decree.{name}: {e}")))?;
+        }
+
+        for (profile_name, profile) in &self.profile {
+            for (name, settings) in &profile.decree {
+                settings.validate().map_err(|e| {
+                    ConfigError::Validation(format!("profile.{profile_name}.decree.{name}: {e}"))
+                })?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -703,5 +718,58 @@ max_line_length = -340
     fn accepts_none_values() {
         let settings = DecreeSettings::default();
         assert!(settings.validate().is_ok());
+    }
+
+    #[test]
+    fn profile_inheritance_applies_parent_before_child() {
+        let toml = r#"
+[decree.supreme]
+max_line_length = 100
+
+[profile.relaxed.decree.supreme]
+max_line_length = 120
+
+[profile.ci]
+inherits = "relaxed"
+
+[profile.ci.decree.supreme]
+max_line_length = 80
+"#;
+
+        let config: DictateConfig = toml::from_str(toml).unwrap();
+        let effective = config.get_profile_config("ci").unwrap();
+
+        assert_eq!(effective.decree["supreme"].max_line_length, Some(80));
+    }
+
+    #[test]
+    fn profile_inheritance_rejects_missing_parent() {
+        let toml = r#"
+[profile.ci]
+inherits = "missing"
+"#;
+
+        let config: DictateConfig = toml::from_str(toml).unwrap();
+        let err = config.get_profile_config("ci").unwrap_err();
+
+        assert!(err.contains("missing"));
+    }
+
+    #[test]
+    fn from_file_validates_profile_decree_settings() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut file,
+            br#"
+[profile.ci.decree.supreme]
+max_line_length = 10
+"#,
+        )
+        .unwrap();
+
+        let err = DictateConfig::from_file(file.path()).unwrap_err();
+
+        assert!(err.to_string().contains("profile.ci.decree.supreme"));
+        assert!(err.to_string().contains("40-500"));
     }
 }

--- a/crates/dictator-kjr/Cargo.toml
+++ b/crates/dictator-kjr/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dictator-kjr"
 version = "0.60.0"
 edition = "2024"
+rust-version.workspace = true
 authors = ["Kim Jong Rails <kim@derails.dev>"]
 license = "GPL"  # Glorious People Licence
 publish = false

--- a/crates/dictator/src/census.rs
+++ b/crates/dictator/src/census.rs
@@ -1,6 +1,7 @@
 //! Census command - shows regime status
 
 use crate::cli::CensusArgs;
+use crate::config::load_dictate_config;
 use camino::Utf8PathBuf;
 use dictator_core::DecreeSettings;
 
@@ -22,23 +23,7 @@ pub fn run_census(
     config_path: Option<Utf8PathBuf>,
     profile: Option<String>,
 ) -> anyhow::Result<()> {
-    // Load decree configuration (with validation)
-    let mut dictate_config = if let Some(p) = config_path.as_ref() {
-        Some(dictator_core::DictateConfig::from_file(p.as_std_path())?)
-    } else {
-        dictator_core::DictateConfig::load_default_strict()?
-    };
-
-    // Apply profile if specified
-    if let Some(ref config) = dictate_config
-        && let Some(ref profile_name) = profile
-    {
-        dictate_config = Some(
-            config
-                .get_profile_config(profile_name)
-                .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?,
-        );
-    }
+    let dictate_config = load_dictate_config(config_path.as_ref(), profile.as_deref())?;
 
     let default_path = Utf8PathBuf::from(".dictate.toml");
     let config_display = config_path.as_ref().unwrap_or(&default_path);

--- a/crates/dictator/src/config.rs
+++ b/crates/dictator/src/config.rs
@@ -3,6 +3,7 @@
 use crate::cli::OutputFormat;
 use anyhow::Result;
 use camino::Utf8PathBuf;
+use dictator_core::DictateConfig;
 use serde::{Deserialize, Serialize};
 use std::fs;
 
@@ -31,5 +32,104 @@ pub fn load_config(path: Option<&Utf8PathBuf>) -> Result<ConfigFile> {
         Ok(toml::from_str(&content)?)
     } else {
         Ok(ConfigFile::default())
+    }
+}
+
+pub fn load_dictate_config(
+    path: Option<&Utf8PathBuf>,
+    profile: Option<&str>,
+) -> Result<Option<DictateConfig>> {
+    let Some(config) = (if let Some(p) = path {
+        Some(DictateConfig::from_file(p.as_std_path())?)
+    } else {
+        DictateConfig::load_default_strict()?
+    }) else {
+        return Ok(None);
+    };
+
+    let selected_profile = profile
+        .or(config.active_profile.as_deref())
+        .or_else(|| config.profile.contains_key("default").then_some("default"));
+
+    let Some(profile_name) = selected_profile else {
+        return Ok(Some(config));
+    };
+
+    let effective = config
+        .get_profile_config(profile_name)
+        .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?;
+
+    Ok(Some(effective))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_config(contents: &[u8]) -> (tempfile::NamedTempFile, Utf8PathBuf) {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, contents).unwrap();
+        let path = Utf8PathBuf::from_path_buf(file.path().to_path_buf()).unwrap();
+        (file, path)
+    }
+
+    #[test]
+    fn load_dictate_config_applies_active_profile() {
+        let (_file, path) = write_config(
+            br#"
+active_profile = "ci"
+
+[decree.supreme]
+max_line_length = 120
+
+[profile.ci.decree.supreme]
+max_line_length = 80
+"#,
+        );
+
+        let config = load_dictate_config(Some(&path), None).unwrap().unwrap();
+
+        assert_eq!(config.decree["supreme"].max_line_length, Some(80));
+    }
+
+    #[test]
+    fn load_dictate_config_explicit_profile_overrides_active_profile() {
+        let (_file, path) = write_config(
+            br#"
+active_profile = "ci"
+
+[decree.supreme]
+max_line_length = 120
+
+[profile.ci.decree.supreme]
+max_line_length = 80
+
+[profile.relaxed.decree.supreme]
+max_line_length = 140
+"#,
+        );
+
+        let config = load_dictate_config(Some(&path), Some("relaxed"))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(config.decree["supreme"].max_line_length, Some(140));
+    }
+
+    #[test]
+    fn load_dictate_config_applies_default_profile_when_present() {
+        let (_file, path) = write_config(
+            br#"
+[decree.supreme]
+max_line_length = 120
+
+[profile.default.decree.supreme]
+max_line_length = 100
+"#,
+        );
+
+        let config = load_dictate_config(Some(&path), None).unwrap().unwrap();
+
+        assert_eq!(config.decree["supreme"].max_line_length, Some(100));
     }
 }

--- a/crates/dictator/src/dictate.rs
+++ b/crates/dictator/src/dictate.rs
@@ -2,10 +2,10 @@
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use dictator_core::DictateConfig;
 use std::fs;
 
 use crate::cli::DictateArgs;
+use crate::config::load_dictate_config;
 use crate::files::collect_all_files;
 use crate::interactive::InteractiveFixer;
 use crate::regime::init_regime_for_files;
@@ -31,23 +31,7 @@ fn run_interactive_dictate(
     println!("🔧 Interactive Fix Mode");
     println!("========================\n");
 
-    // Load configuration
-    let mut decree_config = if let Some(p) = config_path.as_ref() {
-        Some(DictateConfig::from_file(p.as_std_path())?)
-    } else {
-        DictateConfig::load_default_strict()?
-    };
-
-    // Apply profile if specified
-    if let Some(ref config) = decree_config
-        && let Some(ref profile_name) = profile
-    {
-        decree_config = Some(
-            config
-                .get_profile_config(profile_name)
-                .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?,
-        );
-    }
+    let decree_config = load_dictate_config(config_path.as_ref(), profile.as_deref())?;
 
     let mut fixer = InteractiveFixer::new();
 
@@ -78,23 +62,7 @@ fn run_batch_dictate(
         return Ok(());
     }
 
-    // Load configuration for enhanced batch mode
-    let mut decree_config = if let Some(p) = config_path.as_ref() {
-        Some(DictateConfig::from_file(p.as_std_path())?)
-    } else {
-        DictateConfig::load_default_strict()?
-    };
-
-    // Apply profile if specified
-    if let Some(ref config) = decree_config
-        && let Some(ref profile_name) = profile
-    {
-        decree_config = Some(
-            config
-                .get_profile_config(profile_name)
-                .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?,
-        );
-    }
+    let decree_config = load_dictate_config(config_path.as_ref(), profile.as_deref())?;
 
     let file_types = crate::files::detect_file_types(&files);
     let mut regime = init_regime_for_files(&file_types, decree_config.as_ref());

--- a/crates/dictator/src/lint.rs
+++ b/crates/dictator/src/lint.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::sync::{Arc, Mutex};
 
 use crate::cli::{LintArgs, OutputFormat};
-use crate::config::load_config;
+use crate::config::{load_config, load_dictate_config};
 use crate::dictate::apply_single_fix;
 use crate::files::{collect_all_files, detect_file_types};
 use crate::output::{SerializableDiagnostic, byte_to_line_col, print_diagnostic};
@@ -35,23 +35,7 @@ pub fn run_once(
 
     let file_types = detect_file_types(&files);
 
-    // Load decree configuration (with validation)
-    let mut decree_config = if let Some(p) = config_path.as_ref() {
-        Some(dictator_core::DictateConfig::from_file(p.as_std_path())?)
-    } else {
-        dictator_core::DictateConfig::load_default_strict()?
-    };
-
-    // Apply profile if specified
-    if let Some(ref config) = decree_config
-        && let Some(ref profile_name) = profile
-    {
-        decree_config = Some(
-            config
-                .get_profile_config(profile_name)
-                .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?,
-        );
-    }
+    let decree_config = load_dictate_config(config_path.as_ref(), profile.as_deref())?;
 
     // Load native decrees based on detected file types
     let mut regime = init_regime_for_files(&file_types, decree_config.as_ref());

--- a/crates/dictator/src/mcp/linters.rs
+++ b/crates/dictator/src/mcp/linters.rs
@@ -15,6 +15,7 @@ use super::utils::{collect_files, parse_arguments};
 pub fn get_linter_args(command: &str) -> Vec<&'static str> {
     match command {
         "rubocop" => vec!["-A", "--format", "json"],
+        "rubyfmt" => vec!["-i"],
         "eslint" => vec!["--fix", "--format", "json"],
         "biome" => vec!["lint", "--write", "--reporter", "json"],
         "ruff" => vec!["check", "--fix", "--output-format", "json"],

--- a/crates/dictator/src/mcp/regime.rs
+++ b/crates/dictator/src/mcp/regime.rs
@@ -95,6 +95,10 @@ fn load_native_decrees(
     supreme_settings: &dictator_core::config::DecreeSettings,
 ) {
     for (decree_name, settings) in decree_config {
+        if !native_decree_enabled(settings) {
+            continue;
+        }
+
         match decree_name.as_str() {
             "typescript" => {
                 let ts_config = dictator_typescript::config_from_decree_settings(settings);
@@ -137,5 +141,31 @@ fn load_native_decrees(
             }
             _ => {} // Already loaded above; custom WASM decrees handled elsewhere
         }
+    }
+}
+
+fn native_decree_enabled(settings: &dictator_core::config::DecreeSettings) -> bool {
+    settings.enabled != Some(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_decree_enabled_defaults_to_true() {
+        let settings = dictator_core::config::DecreeSettings::default();
+
+        assert!(native_decree_enabled(&settings));
+    }
+
+    #[test]
+    fn native_decree_enabled_respects_false() {
+        let settings = dictator_core::config::DecreeSettings {
+            enabled: Some(false),
+            ..Default::default()
+        };
+
+        assert!(!native_decree_enabled(&settings));
     }
 }

--- a/crates/dictator/src/watch.rs
+++ b/crates/dictator/src/watch.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::cli::{OutputFormat, WatchArgs};
-use crate::config::load_config;
+use crate::config::{load_config, load_dictate_config};
 use crate::output::{SerializableDiagnostic, byte_to_line_col, print_diagnostic};
 use crate::regime::init_regime_for_watch;
 
@@ -30,23 +30,7 @@ pub fn run_watch(
         cfg.format.unwrap_or(OutputFormat::Human)
     };
 
-    // Load decree configuration (with validation)
-    let mut decree_config = if let Some(p) = config_path.as_ref() {
-        Some(dictator_core::DictateConfig::from_file(p.as_std_path())?)
-    } else {
-        dictator_core::DictateConfig::load_default_strict()?
-    };
-
-    // Apply profile if specified
-    if let Some(ref config) = decree_config
-        && let Some(ref profile_name) = profile
-    {
-        decree_config = Some(
-            config
-                .get_profile_config(profile_name)
-                .map_err(|e| anyhow::anyhow!("Profile error: {e}"))?,
-        );
-    }
+    let decree_config = load_dictate_config(config_path.as_ref(), profile.as_deref())?;
 
     // Load native decrees
     let mut regime = init_regime_for_watch(decree_config.as_ref());

--- a/crates/dictator/templates/default.dictate.toml
+++ b/crates/dictator/templates/default.dictate.toml
@@ -32,8 +32,13 @@ extensions = ["md", "mdx"]
 # comment_spacing = true
 #
 # # External linter integration (uncomment to enable)
+# # rubyfmt (recommended): fast, deterministic Ruby formatter
 # [decree.ruby.linter]
-# command = "rubocop"
+# command = "rubyfmt"
+#
+# # Alternative: RuboCop (if you have an existing .rubocop.yml)
+# # [decree.ruby.linter]
+# # command = "rubocop"
 
 # [decree.typescript]
 # # TypeScript/JavaScript structural enforcement


### PR DESCRIPTION
## Summary

Five Dictator decrees rolled into one PR:

- **fix(config): enforce profile inheritance order and validate profile decrees** — parent profiles now resolve before child so the requested profile remains the most specific authority. Missing parents are rejected outright, and profile-level decree settings are validated alongside base decrees. Centralizes the four duplicated load-config-then-apply-profile blocks (census, dictate, lint, watch) into a single `load_dictate_config` helper that also honors `active_profile` and a `default` profile when present.
- **feat(mcp): honor decree enabled flag in native regime loading** — native decrees with `enabled = false` are now skipped during MCP regime loading instead of being dragged in anyway. Unset `enabled` continues to mean `true`.
- **feat(ruby): evict RuboCop as first citizen and crown rubyfmt** — default template recommends `command = "rubyfmt"` with RuboCop demoted to a commented alternative. `linters.rs` dispatches `rubyfmt` with `-i` (write-in-place), routed through the basic-formatter path like rustfmt/gofmt. RuboCop arg dispatch, JSON parser, `.rubocop.yml` project marker, and `# rubocop:disable` directive recognizer all retained for backward compat.
- **docs: align README and FAQ with rubyfmt/Biome first-citizen lineup** — MCP linter section, supremecourt examples, and CI recipe lead with rubyfmt for Ruby and Biome for TypeScript. RuboCop/ESLint kept as legacy alternatives.
- **chore: declare rust-version on dictator-kjr** — discovered by running dictator against its own workspace.

## Test plan

- [x] `cargo test --all` — 220+ tests, all green
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo build --release` — clean
- [x] `dictator lint crates/` — clean (was 1 violation: kjr rust-version, now fixed)
- [ ] CI must pass